### PR TITLE
Include JDK tag to fix gradle_owasp_dependency_check job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
+          jdk_tag: "19.0"
       - hmpps/trivy_latest_scan:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:


### PR DESCRIPTION
It failed https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-adjudications-insights-api/8/workflows/730a36b6-606f-48cd-b044-3ceebbbc8a76/jobs/22