### PR TITLE
NN-5311: 5c - Adjudications resolved with more than one hearing - current month and previous 12 months;

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/controller/ChartController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/controller/ChartController.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.dtos.Chart
 import uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.dtos.ChartDataResponseDto
@@ -17,19 +16,15 @@ class ChartController(private val chartService: ChartService) {
   fun getChart(
     @PathVariable(name = "agencyId") agencyId: String,
     @PathVariable(name = "chartName") chartName: String,
-    @RequestParam
-    (name = "characteristic", required = false) characteristic: String?,
   ): ChartDataResponseDto {
     val chart = chartService.getChart(
       agencyId = agencyId,
       chart = Chart.getChart(chartName),
-      characteristic = characteristic,
     )
     return ChartDataResponseDto(
       agencyId = agencyId,
       chartName = chartName,
       chartEntries = chart,
-      characteristic = characteristic,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/dtos/ChartDataDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/dtos/ChartDataDto.kt
@@ -18,12 +18,6 @@ data class ChartDataResponseDto(
   val chartName: String,
 
   @Schema(
-    description = "Characteristic type",
-    example = "disability,ethnic_group,religion_group,sex_orientation",
-  )
-  val characteristic: String?,
-
-  @Schema(
     description = "List of chart data details",
   )
   val chartEntries: List<Map<String, Any>>,
@@ -66,28 +60,29 @@ data class ChartDataDto(
 )
 
 enum class Chart(val chartName: String, val fileName: String, val tabName: String, val description: String) {
-  CHART_1A("1a", "chart/1a.json", "Totals - adjudications and locations", "Total adjudications - over 24 months"),
-  CHART_1B("1b", "chart/1b.json", "Totals - adjudications and locations", "Total adjudications referred to independent adjudicator – over 24 months"),
-  CHART_1C("1c", "chart/1c.json", "Totals - adjudications and locations", "Number of people with an adjudication in the past 30 days"),
-  CHART_1D("1d", "chart/1d.json", "Totals - adjudications and locations", "Total adjudications by location of adjudication offence – last 30 days"),
-  CHART_1F("1f", "chart/1f.json", "Totals - adjudications and locations", "Total adjudications by residential location of offender"),
+  CHART_1A("1a", "chart/1a.json", "Totals - adjudications and locations", "Adjudication reports created - over 24 months"),
+  CHART_1B("1b", "chart/1b.json", "Totals - adjudications and locations", "Adjudication reports referred to independent adjudicator – over 24 months"),
+  CHART_1C("1c", "chart/1c.json", "Totals - adjudications and locations", "Number of people placed on report in the past 30 days"),
+  CHART_1D("1d", "chart/1d.json", "Totals - adjudications and locations", "Adjudication reports by location of adjudication incident – last 30 days"),
+  CHART_1F("1f", "chart/1f.json", "Totals - adjudications and locations", "Adjudication reports by residential location of prisoner – last 30 days"),
 
-  CHART_2A("2a", "chart/2a.json", "Protected characteristics and vulnerabilities", "Percentage and number of prisoners in the establishment by {{ religion }} currently"),
-  CHART_2B("2b", "chart/2b.json", "Protected characteristics and vulnerabilities", "Percentage and number of prisoners with an adjudication by {{ religion }} – last 30 days"),
-  CHART_2D("2d", "chart/2d.json", "Protected characteristics and vulnerabilities", "Offence type by protected characteristic or vulnerability - last 30 days"),
-  CHART_2E("2e", "chart/2e.json", "Protected characteristics and vulnerabilities", "Punishment by protected characteristic or vulnerability - last 30 days"),
-  CHART_2F("2f", "chart/2f.json", "Protected characteristics and vulnerabilities", "Plea by protected characteristic or vulnerability - last 30 days"),
-  CHART_2G("2g", "chart/2g.json", "Protected characteristics and vulnerabilities", "Finding by protected characteristic or vulnerability - last 30 days"),
+  CHART_2A("2a", "chart/2a.json", "Protected characteristics and vulnerabilities", "Overview of prisoners in the establishment currently"),
+  CHART_2B("2b", "chart/2b.json", "Protected characteristics and vulnerabilities", "Adjudication reports by protected or responsivity characteristic – last 30 days"),
+  CHART_2D("2d", "chart/2d.json", "Protected characteristics and vulnerabilities", "Adjudication offence type by protected or responsivity characteristic - last 30 days"),
+  CHART_2E("2e", "chart/2e.json", "Protected characteristics and vulnerabilities", "Punishment by protected or responsivity characteristic - last 30 days"),
+  CHART_2F("2f", "chart/2f.json", "Protected characteristics and vulnerabilities", "Plea by protected or responsivity characteristic - last 30 days"),
+  CHART_2G("2g", "chart/2g.json", "Protected characteristics and vulnerabilities", "Finding by protected or responsivity characteristic - last 30 days"),
 
-  CHART_3A("3a", "chart/3a.json", "Offence type", "Total adjudications by offence type – current month and previous 12 months"),
-  CHART_3B("3b", "chart/3b.json", "Offence type", "Offence type by location – last 30 days"),
+  CHART_3A("3a", "chart/3a.json", "Offence type", "Adjudication offence types – current month and previous 12 months"),
+  CHART_3B("3b", "chart/3b.json", "Offence type", "Adjudication offence type by location – last 30 days"),
 
-  CHART_4A("4a", "chart/4a.json", "Punishments", "Total adjudications by punishment – current month and previous 12 months"),
-  CHART_4B("4b", "chart/4b.json", "Punishments", "Total adjudications for each offence type broken down by punishment - current month and previous 12 months"),
-  CHART_4C("4c", "chart/4c.json", "Punishments", "Percentage of suspended and activated punishments - current month and last 12 months"),
+  CHART_4A("4a", "chart/4a.json", "Punishments", "Punishments given – current month and previous 12 months"),
+  CHART_4B("4b", "chart/4b.json", "Punishments", "Punishments given for each adjudication offence type - current month and previous 12 months"),
+  CHART_4C("4c", "chart/4c.json", "Punishments", "Suspended and activated punishments - current month and last 12 months"),
 
-  CHART_5A("5a", "chart/5a.json", "Pleas and findings", "Total adjudications by plea – current month and previous 12 months"),
-  CHART_5B("5b", "chart/5b.json", "Pleas and findings", "Total adjudications by finding – current month and previous 12 months"),
+  CHART_5A("5a", "chart/5a.json", "Pleas and findings", "Pleas given – current month and previous 12 months"),
+  CHART_5B("5b", "chart/5b.json", "Pleas and findings", "Findings – current month and previous 12 months"),
+  CHART_5C("5c", "chart/5c.json", "Pleas and findings", "Adjudications resolved with more than one hearing – current month and previous 12 months "),
   ;
   companion object {
     fun getChart(chartName: String) = Chart.values().first { it.chartName == chartName }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/service/ChartService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/service/ChartService.kt
@@ -8,15 +8,11 @@ import uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.dtos.Chart
 @Service
 class ChartService(private val s3Facade: S3Facade) {
 
-  fun getChart(agencyId: String, chart: Chart, characteristic: String?): List<Map<String, Any>> {
+  fun getChart(agencyId: String, chart: Chart): List<Map<String, Any>> {
     val fileAsString = this.s3Facade.getFile(chart.fileName)
     val items: Map<String, List<Map<String, Any>>> =
       Gson().fromJson(fileAsString, object : TypeToken<Map<String, List<Map<String, Any>>>>() {}.type)
 
-    val result = items[agencyId].orEmpty()
-    if (characteristic != null) {
-      return result.filter { it["characteristic"] == characteristic }
-    }
-    return result
+    return items[agencyId].orEmpty()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/integration/ChartControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/integration/ChartControllerTest.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.integration
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.mock.mockito.MockBean
 import uk.gov.justice.digital.hmpps.hmppsadjudicationsinsightsapi.service.ChartService
@@ -19,7 +18,6 @@ class ChartControllerTest : IntegrationTestBase() {
       chartService.getChart(
         any(),
         any(),
-        anyOrNull(),
       ),
     ).thenReturn(
       listOf(
@@ -39,22 +37,6 @@ class ChartControllerTest : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/api/data-insights/chart/ACI/1a")
-      .headers(setHeaders())
-      .exchange()
-      .expectStatus()
-      .isOk
-      .expectBody()
-      .jsonPath("agencyId").isEqualTo("ACI")
-      .jsonPath("chartName").isEqualTo("1a")
-      .jsonPath("chartEntries.length()").isEqualTo(2)
-  }
-
-  @Test
-  fun `Get chart data by agencyId and characteristic`() {
-    // Expected structure: {"agencyId":"ACI","chartName":"1a","chartEntries":[ ... mocked ] }
-
-    webTestClient.get()
-      .uri("/api/data-insights/chart/ACI/1a?characteristic?ethnic_group")
       .headers(setHeaders())
       .exchange()
       .expectStatus()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/service/ChartServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsadjudicationsinsightsapi/service/ChartServiceTest.kt
@@ -20,7 +20,7 @@ class ChartServiceTest {
 
     whenever(s3Facade.getFile(chart.fileName)).thenReturn(fileContent)
 
-    val chart = chartService.getChart(agencyId = "ACI", chart = chart, characteristic = null)
+    val chart = chartService.getChart(agencyId = "ACI", chart = chart)
     assertThat(chart).isNotEmpty
   }
 }

--- a/src/test/resources/test-data/chart/5c.json
+++ b/src/test/resources/test-data/chart/5c.json
@@ -1,0 +1,14877 @@
+{
+  "ACI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 66,
+      "count_more": 54,
+      "count": 120,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 43,
+      "count": 134,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 73,
+      "count": 110,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 27,
+      "count": 72,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 82,
+      "count": 165,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 90,
+      "count_more": 29,
+      "count": 119,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 84,
+      "count": 138,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 12,
+      "count": 107,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 70,
+      "count": 84,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 9,
+      "count": 47,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 92,
+      "count": 134,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 18,
+      "count_more": 89,
+      "count": 107,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 89,
+      "count": 173,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "AGI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 33,
+      "count": 39,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 66,
+      "count": 123,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 95,
+      "count": 166,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 92,
+      "count": 188,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 97,
+      "count": 117,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 69,
+      "count_more": 58,
+      "count": 127,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 55,
+      "count": 103,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 19,
+      "count": 33,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 10,
+      "count": 14,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 55,
+      "count": 130,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 12,
+      "count": 80,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 51,
+      "count": 119,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 40,
+      "count": 66,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    }
+  ],
+  "ASI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 85,
+      "count": 126,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 48,
+      "count": 92,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 44,
+      "count": 131,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 88,
+      "count": 126,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 16,
+      "count": 38,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 55,
+      "count": 72,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 2,
+      "count": 80,
+      "prop_one": 0.98,
+      "prop_more": 0.02
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 29,
+      "count": 88,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 87,
+      "count": 133,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 27,
+      "count": 38,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 74,
+      "count_more": 99,
+      "count": 173,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 65,
+      "count": 149,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 18,
+      "count_more": 26,
+      "count": 44,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    }
+  ],
+  "AYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 34,
+      "count": 42,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 47,
+      "count": 128,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 96,
+      "count": 137,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 99,
+      "count": 123,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 5,
+      "count": 94,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 59,
+      "count": 155,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 56,
+      "count": 80,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 6,
+      "count": 14,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 19,
+      "count": 106,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 72,
+      "count": 140,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 68,
+      "count": 164,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 43,
+      "count": 44,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 82,
+      "count": 173,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    }
+  ],
+  "BAI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 46,
+      "count": 113,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 80,
+      "count": 91,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 38,
+      "count": 105,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 55,
+      "count": 117,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 47,
+      "count_more": 56,
+      "count": 103,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 41,
+      "count": 117,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 9,
+      "count": 94,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 49,
+      "count_more": 71,
+      "count": 120,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 15,
+      "count": 56,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 24,
+      "count": 86,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 92,
+      "count": 139,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 96,
+      "count": 180,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 99,
+      "count": 111,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    }
+  ],
+  "BCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 90,
+      "count": 119,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 75,
+      "count": 86,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 32,
+      "count": 115,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 83,
+      "count": 84,
+      "prop_one": 0.01,
+      "prop_more": 0.99
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 31,
+      "count": 43,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 85,
+      "count": 112,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 59,
+      "count": 134,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 35,
+      "count": 97,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 39,
+      "count": 92,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 48,
+      "count": 74,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 5,
+      "count": 57,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 75,
+      "count": 152,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 52,
+      "count": 75,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    }
+  ],
+  "BFI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 57,
+      "count": 65,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 55,
+      "count": 87,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 73,
+      "count": 105,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 6,
+      "count": 101,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 32,
+      "count": 82,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 52,
+      "count": 131,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 79,
+      "count": 161,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 35,
+      "count": 51,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 13,
+      "count": 42,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 38,
+      "count": 132,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 70,
+      "count": 157,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 46,
+      "count": 124,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 83,
+      "count_more": 85,
+      "count": 168,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "BLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 62,
+      "count": 122,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 21,
+      "count": 55,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 13,
+      "count": 15,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 27,
+      "count": 36,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 77,
+      "count": 100,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 53,
+      "count": 144,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 22,
+      "count_more": 93,
+      "count": 115,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 73,
+      "count": 103,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 20,
+      "count": 68,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 71,
+      "count": 99,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 67,
+      "count": 119,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 53,
+      "count": 118,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 39,
+      "count": 51,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    }
+  ],
+  "BMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 69,
+      "count": 156,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 17,
+      "count": 105,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 30,
+      "count_more": 59,
+      "count": 89,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 24,
+      "count": 66,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 51,
+      "count_more": 54,
+      "count": 105,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 44,
+      "count": 81,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 42,
+      "count": 118,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 99,
+      "count": 164,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 76,
+      "count": 139,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 23,
+      "count": 26,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 67,
+      "count": 79,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 93,
+      "count_more": 19,
+      "count": 112,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 34,
+      "count": 75,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    }
+  ],
+  "BNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 36,
+      "count": 53,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 26,
+      "count_more": 45,
+      "count": 71,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 16,
+      "count": 30,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 65,
+      "count_more": 99,
+      "count": 164,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 26,
+      "count_more": 24,
+      "count": 50,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 31,
+      "count": 129,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 52,
+      "count": 56,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 30,
+      "count": 33,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 31,
+      "count": 55,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 25,
+      "count": 37,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 75,
+      "count": 140,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 76,
+      "count": 87,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 22,
+      "count_more": 84,
+      "count": 106,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    }
+  ],
+  "BRI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 25,
+      "count": 62,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 65,
+      "count": 135,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 23,
+      "count": 59,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 40,
+      "count": 57,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 39,
+      "count": 122,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 98,
+      "count": 141,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 48,
+      "count": 49,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 46,
+      "count": 100,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 38,
+      "count": 135,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 3,
+      "count": 90,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 38,
+      "count": 101,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 79,
+      "count": 147,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 52,
+      "count": 136,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    }
+  ],
+  "BSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 37,
+      "count": 59,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 56,
+      "count": 77,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 23,
+      "count": 46,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 76,
+      "count": 93,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 50,
+      "count": 106,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 39,
+      "count": 84,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 58,
+      "count": 143,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 9,
+      "count_more": 60,
+      "count": 69,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 61,
+      "count": 77,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 56,
+      "count": 123,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 45,
+      "count": 141,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 37,
+      "count": 87,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 55,
+      "count": 142,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    }
+  ],
+  "BWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 35,
+      "count": 106,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 41,
+      "count": 49,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 87,
+      "count": 104,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 72,
+      "count_more": 1,
+      "count": 73,
+      "prop_one": 0.99,
+      "prop_more": 0.01
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 4,
+      "count": 46,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 1,
+      "count": 37,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 90,
+      "count": 155,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 63,
+      "count": 80,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 33,
+      "count": 112,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 28,
+      "count": 44,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 42,
+      "count": 98,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 68,
+      "count": 87,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 58,
+      "count": 150,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    }
+  ],
+  "BXI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 39,
+      "count": 82,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 26,
+      "count_more": 82,
+      "count": 108,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 32,
+      "count": 74,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 23,
+      "count": 120,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 74,
+      "count": 149,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 93,
+      "count": 169,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 82,
+      "count": 144,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 15,
+      "count_more": 88,
+      "count": 103,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 19,
+      "count": 51,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 61,
+      "count_more": 7,
+      "count": 68,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 2,
+      "count": 80,
+      "prop_one": 0.98,
+      "prop_more": 0.02
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 28,
+      "count": 81,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 75,
+      "count": 133,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    }
+  ],
+  "BZI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 70,
+      "count": 148,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 35,
+      "count": 127,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 31,
+      "count": 53,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 45,
+      "count": 123,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 70,
+      "count": 149,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 55,
+      "count": 90,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 94,
+      "count": 123,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 35,
+      "count_more": 5,
+      "count": 40,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 64,
+      "count": 109,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 64,
+      "count": 115,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 79,
+      "count": 167,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 91,
+      "count": 139,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 25,
+      "count": 37,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    }
+  ],
+  "CDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 86,
+      "count": 124,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 30,
+      "count_more": 35,
+      "count": 65,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 13,
+      "count_more": 22,
+      "count": 35,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 35,
+      "count": 121,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 64,
+      "count": 138,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 5,
+      "count": 37,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 4,
+      "count": 27,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 84,
+      "count": 154,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 9,
+      "count": 21,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 60,
+      "count": 70,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 45,
+      "count": 76,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 40,
+      "count": 81,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 63,
+      "count": 141,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    }
+  ],
+  "CFI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 22,
+      "count": 34,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 29,
+      "count": 105,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 11,
+      "count": 42,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 0,
+      "count": 44,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 13,
+      "count_more": 92,
+      "count": 105,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 36,
+      "count": 40,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 39,
+      "count": 59,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 25,
+      "count_more": 56,
+      "count": 81,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 45,
+      "count": 142,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 50,
+      "count": 115,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 51,
+      "count": 75,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 27,
+      "count": 54,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 44,
+      "count": 63,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    }
+  ],
+  "CKI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 91,
+      "count": 112,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 97,
+      "count": 117,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 45,
+      "count": 87,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 0,
+      "count": 5,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 62,
+      "count": 155,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 59,
+      "count": 107,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 13,
+      "count": 101,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 13,
+      "count": 98,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 18,
+      "count": 46,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 66,
+      "count": 118,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 6,
+      "count": 82,
+      "prop_one": 0.93,
+      "prop_more": 0.07
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 36,
+      "count": 66,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 51,
+      "count": 139,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    }
+  ],
+  "CLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 0,
+      "count": 56,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 41,
+      "count": 59,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 3,
+      "count": 85,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 14,
+      "count": 71,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 50,
+      "count": 143,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 96,
+      "count": 102,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 89,
+      "count": 113,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 33,
+      "count": 75,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 55,
+      "count_more": 43,
+      "count": 98,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 40,
+      "count": 42,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 45,
+      "count": 123,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 0,
+      "count": 65,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 87,
+      "count": 183,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    }
+  ],
+  "CWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 10,
+      "count": 98,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 80,
+      "count_more": 16,
+      "count": 96,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 47,
+      "count_more": 57,
+      "count": 104,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 80,
+      "count": 80,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 14,
+      "count": 90,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 71,
+      "count": 164,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 37,
+      "count": 48,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 79,
+      "count": 138,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 47,
+      "count": 112,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 5,
+      "count": 22,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 93,
+      "count_more": 26,
+      "count": 119,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 9,
+      "count": 51,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 29,
+      "count": 107,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    }
+  ],
+  "DAI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 60,
+      "count": 80,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 45,
+      "count": 68,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 96,
+      "count": 124,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 78,
+      "count": 156,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 4,
+      "count": 24,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 93,
+      "count": 125,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 14,
+      "count": 47,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 38,
+      "count": 119,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 19,
+      "count": 66,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 60,
+      "count": 136,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 60,
+      "count_more": 0,
+      "count": 60,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 71,
+      "count": 138,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 59,
+      "count": 96,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    }
+  ],
+  "DGI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 74,
+      "count": 108,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 25,
+      "count": 67,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 32,
+      "count": 125,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 31,
+      "count": 99,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 7,
+      "count": 74,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 81,
+      "count": 118,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 43,
+      "count": 71,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 40,
+      "count": 138,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 94,
+      "count": 178,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 38,
+      "count": 64,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 25,
+      "count": 72,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 59,
+      "count": 64,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 10,
+      "count": 69,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    }
+  ],
+  "DHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 92,
+      "count": 112,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 10,
+      "count_more": 38,
+      "count": 48,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 32,
+      "count": 117,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 55,
+      "count_more": 94,
+      "count": 149,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 52,
+      "count": 128,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 9,
+      "count": 47,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 30,
+      "count": 63,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 83,
+      "count": 175,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 78,
+      "count": 106,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 49,
+      "count": 107,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 45,
+      "count": 78,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 99,
+      "count": 137,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 93,
+      "count": 184,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "DMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 88,
+      "count": 169,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 17,
+      "count": 22,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 8,
+      "count": 12,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 78,
+      "count": 120,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 91,
+      "count": 100,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 11,
+      "count": 96,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 16,
+      "count": 97,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 89,
+      "count": 155,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 99,
+      "count": 112,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 65,
+      "count": 118,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 58,
+      "count": 156,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 96,
+      "count": 161,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 1,
+      "count": 28,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    }
+  ],
+  "DNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 17,
+      "count": 94,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 40,
+      "count": 59,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 7,
+      "count": 104,
+      "prop_one": 0.93,
+      "prop_more": 0.07
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 82,
+      "count": 86,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 22,
+      "count": 53,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 94,
+      "count": 121,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 51,
+      "count": 85,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 8,
+      "count": 53,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 24,
+      "count": 93,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 33,
+      "count": 109,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 5,
+      "count": 25,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 20,
+      "count": 93,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 55,
+      "count": 150,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    }
+  ],
+  "DTI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 40,
+      "count": 82,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 66,
+      "count_more": 76,
+      "count": 142,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 39,
+      "count_more": 78,
+      "count": 117,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 21,
+      "count": 98,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 18,
+      "count": 67,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 40,
+      "count": 57,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 81,
+      "count": 88,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 24,
+      "count": 31,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 4,
+      "count": 85,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 92,
+      "count": 169,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 29,
+      "count": 68,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 44,
+      "count_more": 33,
+      "count": 77,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 15,
+      "count_more": 5,
+      "count": 20,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    }
+  ],
+  "DWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 40,
+      "count": 68,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 39,
+      "count": 85,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 88,
+      "count": 180,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 17,
+      "count": 59,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 21,
+      "count": 44,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 85,
+      "count": 155,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 61,
+      "count_more": 26,
+      "count": 87,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 38,
+      "count": 38,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 78,
+      "count": 143,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 10,
+      "count": 31,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 72,
+      "count": 159,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 3,
+      "count": 57,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 91,
+      "count": 175,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    }
+  ],
+  "EEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 29,
+      "count": 122,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 55,
+      "count": 79,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 85,
+      "count": 93,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 99,
+      "count": 184,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 20,
+      "count": 40,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 95,
+      "count": 166,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 16,
+      "count": 21,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 41,
+      "count": 69,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 56,
+      "count": 152,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 61,
+      "count": 129,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 17,
+      "count": 71,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 44,
+      "count": 58,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 76,
+      "count": 167,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    }
+  ],
+  "EHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 10,
+      "count_more": 27,
+      "count": 37,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 16,
+      "count": 62,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 62,
+      "count": 107,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 51,
+      "count": 129,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 68,
+      "count": 153,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 5,
+      "count": 101,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 19,
+      "count": 38,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 14,
+      "count": 57,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 6,
+      "count_more": 86,
+      "count": 92,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 26,
+      "count": 104,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 32,
+      "count": 117,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 29,
+      "count": 92,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 58,
+      "count": 139,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    }
+  ],
+  "ESI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 63,
+      "count": 111,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 16,
+      "count": 43,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 91,
+      "count": 95,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 27,
+      "count": 109,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 46,
+      "count": 121,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 87,
+      "count": 173,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 55,
+      "count": 76,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 6,
+      "count_more": 7,
+      "count": 13,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 87,
+      "count": 126,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 96,
+      "count": 104,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 84,
+      "count": 176,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 80,
+      "count": 108,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 83,
+      "count": 145,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    }
+  ],
+  "EWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 35,
+      "count": 81,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 77,
+      "count": 95,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 90,
+      "count": 185,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 86,
+      "count": 185,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 25,
+      "count": 101,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 30,
+      "count_more": 9,
+      "count": 39,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 54,
+      "count": 127,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 58,
+      "count": 110,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 38,
+      "count": 109,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 99,
+      "count": 151,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 81,
+      "count": 124,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 5,
+      "count": 8,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 39,
+      "count": 109,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    }
+  ],
+  "EXI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 51,
+      "count_more": 27,
+      "count": 78,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 37,
+      "count": 116,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 90,
+      "count": 113,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 62,
+      "count": 129,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 29,
+      "count": 100,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 72,
+      "count": 171,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 64,
+      "count": 78,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 84,
+      "count": 122,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 60,
+      "count": 145,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 58,
+      "count": 95,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 26,
+      "count": 106,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 24,
+      "count": 77,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 55,
+      "count_more": 90,
+      "count": 145,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    }
+  ],
+  "EYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 87,
+      "count": 149,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 97,
+      "count": 156,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 87,
+      "count": 132,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 94,
+      "count": 157,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 16,
+      "count": 73,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 52,
+      "count_more": 99,
+      "count": 151,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 36,
+      "count": 134,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 14,
+      "count": 110,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 36,
+      "count_more": 44,
+      "count": 80,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 22,
+      "count": 102,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 25,
+      "count_more": 98,
+      "count": 123,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 12,
+      "count": 45,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 89,
+      "count_more": 3,
+      "count": 92,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    }
+  ],
+  "FBI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 47,
+      "count_more": 54,
+      "count": 101,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 68,
+      "count": 116,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 23,
+      "count": 39,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 83,
+      "count": 167,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 12,
+      "count": 33,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 65,
+      "count_more": 12,
+      "count": 77,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 25,
+      "count": 38,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 82,
+      "count": 94,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 0,
+      "count": 31,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 41,
+      "count": 46,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 64,
+      "count": 150,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 95,
+      "count": 153,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 75,
+      "count": 139,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    }
+  ],
+  "FDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 73,
+      "count": 93,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 44,
+      "count": 132,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 54,
+      "count_more": 53,
+      "count": 107,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 12,
+      "count": 111,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 98,
+      "count": 130,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 3,
+      "count": 19,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 13,
+      "count": 23,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 67,
+      "count": 131,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 10,
+      "count": 64,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 72,
+      "count": 79,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 8,
+      "count": 19,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 97,
+      "count": 155,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 18,
+      "count_more": 46,
+      "count": 64,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    }
+  ],
+  "FEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 59,
+      "count": 119,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 75,
+      "count": 125,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 9,
+      "count": 38,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 91,
+      "count": 100,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 82,
+      "count": 174,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 51,
+      "count": 124,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 47,
+      "count": 120,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 91,
+      "count": 94,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 78,
+      "count": 164,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 55,
+      "count": 101,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 86,
+      "count": 159,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 25,
+      "count": 78,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 54,
+      "count": 110,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    }
+  ],
+  "FHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 42,
+      "count": 138,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 56,
+      "count": 92,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 4,
+      "count": 75,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 89,
+      "count": 90,
+      "prop_one": 0.01,
+      "prop_more": 0.99
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 62,
+      "count": 70,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 3,
+      "count": 92,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 23,
+      "count": 81,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 78,
+      "count": 110,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 68,
+      "count": 70,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 80,
+      "count": 91,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 84,
+      "count": 122,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 25,
+      "count_more": 7,
+      "count": 32,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 55,
+      "count": 55,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    }
+  ],
+  "FKI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 13,
+      "count_more": 43,
+      "count": 56,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 53,
+      "count_more": 31,
+      "count": 84,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 23,
+      "count": 83,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 35,
+      "count": 118,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 70,
+      "count": 155,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 65,
+      "count": 146,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 56,
+      "count": 148,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 74,
+      "count_more": 84,
+      "count": 158,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 57,
+      "count_more": 13,
+      "count": 70,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 5,
+      "count": 28,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 91,
+      "count": 189,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 64,
+      "count": 133,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 79,
+      "count": 149,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    }
+  ],
+  "FMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 95,
+      "count": 143,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 80,
+      "count": 177,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 11,
+      "count": 42,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 33,
+      "count": 121,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 8,
+      "count": 22,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 94,
+      "count": 129,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 46,
+      "count": 79,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 57,
+      "count": 90,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 48,
+      "count": 85,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 71,
+      "count": 130,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 18,
+      "count": 59,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 7,
+      "count": 89,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 69,
+      "count": 134,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "FNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 40,
+      "count_more": 77,
+      "count": 117,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 26,
+      "count": 93,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 55,
+      "count": 100,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 46,
+      "count": 73,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 81,
+      "count": 140,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 39,
+      "count_more": 51,
+      "count": 90,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 16,
+      "count": 57,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 96,
+      "count": 113,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 18,
+      "count": 48,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 86,
+      "count": 113,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 99,
+      "count_more": 46,
+      "count": 145,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 26,
+      "count": 108,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 57,
+      "count": 58,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    }
+  ],
+  "FSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 14,
+      "count": 37,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 67,
+      "count": 163,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 10,
+      "count_more": 8,
+      "count": 18,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 2,
+      "count": 24,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 54,
+      "count": 118,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 4,
+      "count": 15,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 79,
+      "count": 87,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 69,
+      "count": 131,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 44,
+      "count_more": 0,
+      "count": 44,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 82,
+      "count": 101,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 24,
+      "count": 89,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 85,
+      "count": 119,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 37,
+      "count": 58,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    }
+  ],
+  "FWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 26,
+      "count": 96,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 98,
+      "count": 129,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 11,
+      "count": 81,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 24,
+      "count": 95,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 25,
+      "count": 99,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 37,
+      "count": 82,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 25,
+      "count_more": 71,
+      "count": 96,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 6,
+      "count": 43,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 61,
+      "count": 78,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 88,
+      "count": 176,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 27,
+      "count": 92,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 13,
+      "count": 107,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 75,
+      "count": 155,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    }
+  ],
+  "FYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 20,
+      "count": 70,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 11,
+      "count": 60,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 54,
+      "count": 121,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 98,
+      "count": 133,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 69,
+      "count_more": 59,
+      "count": 128,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 79,
+      "count": 107,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 89,
+      "count": 117,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 18,
+      "count_more": 93,
+      "count": 111,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 40,
+      "count": 43,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 24,
+      "count": 47,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 35,
+      "count_more": 54,
+      "count": 89,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 39,
+      "count": 79,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 53,
+      "count": 99,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    }
+  ],
+  "GHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 45,
+      "count": 54,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 98,
+      "count": 176,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 46,
+      "count": 102,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 28,
+      "count": 109,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 32,
+      "count": 70,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 82,
+      "count": 180,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 79,
+      "count": 175,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 60,
+      "count": 147,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 40,
+      "count": 81,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 73,
+      "count": 113,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 10,
+      "count": 91,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 74,
+      "count_more": 67,
+      "count": 141,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 11,
+      "count": 37,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    }
+  ],
+  "GMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 55,
+      "count": 129,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 65,
+      "count": 99,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 63,
+      "count": 113,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 79,
+      "count": 129,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 78,
+      "count": 160,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 63,
+      "count": 161,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 96,
+      "count": 99,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 98,
+      "count": 138,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 34,
+      "count": 84,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 90,
+      "count_more": 47,
+      "count": 137,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 61,
+      "count": 81,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 61,
+      "count_more": 73,
+      "count": 134,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 89,
+      "count_more": 92,
+      "count": 181,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "GNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 76,
+      "count": 108,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 70,
+      "count": 99,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 6,
+      "count": 48,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 81,
+      "count": 100,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 4,
+      "count": 53,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 45,
+      "count": 138,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 77,
+      "count": 104,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 55,
+      "count_more": 5,
+      "count": 60,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 62,
+      "count": 130,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 50,
+      "count": 120,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 42,
+      "count": 136,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 60,
+      "count": 94,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 57,
+      "count": 142,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    }
+  ],
+  "GTI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 80,
+      "count_more": 39,
+      "count": 119,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 70,
+      "count": 151,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 10,
+      "count_more": 2,
+      "count": 12,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 7,
+      "count_more": 55,
+      "count": 62,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 56,
+      "count": 94,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 24,
+      "count": 106,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 16,
+      "count": 24,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 5,
+      "count": 18,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 46,
+      "count": 144,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 29,
+      "count": 61,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 43,
+      "count": 107,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 9,
+      "count_more": 18,
+      "count": 27,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 44,
+      "count": 124,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    }
+  ],
+  "HBI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 55,
+      "count_more": 70,
+      "count": 125,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 45,
+      "count": 78,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 90,
+      "count": 123,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 32,
+      "count": 76,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 79,
+      "count": 117,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 31,
+      "count": 73,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 55,
+      "count_more": 66,
+      "count": 121,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 41,
+      "count": 75,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 90,
+      "count": 157,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 79,
+      "count": 177,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 29,
+      "count": 61,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 23,
+      "count": 109,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 48,
+      "count": 130,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    }
+  ],
+  "HCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 47,
+      "count": 89,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 16,
+      "count": 80,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 68,
+      "count": 156,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 48,
+      "count": 52,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 94,
+      "count_more": 81,
+      "count": 175,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 81,
+      "count": 87,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 6,
+      "count_more": 74,
+      "count": 80,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 56,
+      "count": 77,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 55,
+      "count": 143,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 25,
+      "count": 44,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 6,
+      "count_more": 45,
+      "count": 51,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 6,
+      "count": 46,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 84,
+      "count": 117,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    }
+  ],
+  "HDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 48,
+      "count": 50,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 61,
+      "count": 123,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 91,
+      "count": 151,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 47,
+      "count_more": 88,
+      "count": 135,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 69,
+      "count": 77,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 68,
+      "count": 113,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 84,
+      "count": 142,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 93,
+      "count_more": 39,
+      "count": 132,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 59,
+      "count": 146,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 27,
+      "count": 77,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 54,
+      "count": 136,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 9,
+      "count": 105,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 68,
+      "count": 155,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    }
+  ],
+  "HEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 8,
+      "count": 27,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 13,
+      "count_more": 38,
+      "count": 51,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 21,
+      "count": 117,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 41,
+      "count": 99,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 26,
+      "count": 114,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 1,
+      "count": 88,
+      "prop_one": 0.99,
+      "prop_more": 0.01
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 81,
+      "count": 147,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 12,
+      "count": 91,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 90,
+      "count": 165,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 8,
+      "count": 35,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 87,
+      "count": 116,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 91,
+      "count": 159,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 50,
+      "count": 60,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    }
+  ],
+  "HHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 27,
+      "count": 28,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 61,
+      "count_more": 89,
+      "count": 150,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 93,
+      "count": 98,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 73,
+      "count": 141,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 65,
+      "count": 108,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 97,
+      "count": 171,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 87,
+      "count": 94,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 6,
+      "count": 49,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 33,
+      "count": 129,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 60,
+      "count_more": 41,
+      "count": 101,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 66,
+      "count": 100,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 3,
+      "count": 4,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 10,
+      "count": 51,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    }
+  ],
+  "HII": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 84,
+      "count": 119,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 80,
+      "count": 125,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 94,
+      "count": 186,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 76,
+      "count": 91,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 50,
+      "count": 96,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 45,
+      "count": 87,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 95,
+      "count": 123,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 71,
+      "count": 97,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 77,
+      "count": 124,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 27,
+      "count": 77,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 76,
+      "count": 148,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 70,
+      "count": 74,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 49,
+      "count": 145,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    }
+  ],
+  "HLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 62,
+      "count": 65,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 27,
+      "count": 111,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 99,
+      "count": 170,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 7,
+      "count_more": 94,
+      "count": 101,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 82,
+      "count": 109,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 74,
+      "count": 169,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 81,
+      "count": 113,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 32,
+      "count": 91,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 89,
+      "count_more": 79,
+      "count": 168,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 82,
+      "count": 145,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 5,
+      "count": 28,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 53,
+      "count": 104,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 49,
+      "count_more": 31,
+      "count": 80,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    }
+  ],
+  "HMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 67,
+      "count": 91,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 38,
+      "count": 130,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 67,
+      "count": 96,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 19,
+      "count": 100,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 6,
+      "count": 14,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 58,
+      "count": 115,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 10,
+      "count": 85,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 31,
+      "count": 34,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 85,
+      "count": 183,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 99,
+      "count_more": 0,
+      "count": 99,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 83,
+      "count": 113,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 21,
+      "count": 34,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 60,
+      "count": 155,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    }
+  ],
+  "HOI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 25,
+      "count_more": 74,
+      "count": 99,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 20,
+      "count": 80,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 61,
+      "count": 109,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 8,
+      "count": 22,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 66,
+      "count_more": 23,
+      "count": 89,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 40,
+      "count": 122,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 68,
+      "count": 78,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 27,
+      "count": 74,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 6,
+      "count": 17,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 89,
+      "count": 131,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 89,
+      "count_more": 24,
+      "count": 113,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 83,
+      "count_more": 81,
+      "count": 164,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 68,
+      "count": 113,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    }
+  ],
+  "HPI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 66,
+      "count": 149,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 65,
+      "count": 154,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 68,
+      "count": 96,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 47,
+      "count_more": 68,
+      "count": 115,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 73,
+      "count": 123,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 89,
+      "count": 151,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 80,
+      "count": 128,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 87,
+      "count": 159,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 30,
+      "count": 110,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 64,
+      "count": 112,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 37,
+      "count": 106,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 1,
+      "count": 87,
+      "prop_one": 0.99,
+      "prop_more": 0.01
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 84,
+      "count": 181,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    }
+  ],
+  "HVI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 84,
+      "count": 106,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 19,
+      "count": 86,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 31,
+      "count": 40,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 80,
+      "count_more": 34,
+      "count": 114,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 56,
+      "count": 68,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 8,
+      "count": 32,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 22,
+      "count_more": 32,
+      "count": 54,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 45,
+      "count": 140,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 61,
+      "count": 74,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 6,
+      "count_more": 15,
+      "count": 21,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 19,
+      "count": 50,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 74,
+      "count": 138,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 95,
+      "count": 126,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    }
+  ],
+  "ISI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 54,
+      "count": 114,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 92,
+      "count": 125,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 25,
+      "count": 99,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 6,
+      "count": 48,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 72,
+      "count": 84,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 3,
+      "count": 62,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 15,
+      "count": 38,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 26,
+      "count": 47,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 74,
+      "count": 140,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 25,
+      "count": 83,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 25,
+      "count": 46,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 44,
+      "count": 45,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 35,
+      "count": 89,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    }
+  ],
+  "IWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 27,
+      "count": 48,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 62,
+      "count": 154,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 36,
+      "count": 135,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 57,
+      "count": 72,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 22,
+      "count": 45,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 7,
+      "count": 71,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 69,
+      "count": 166,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 15,
+      "count": 26,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 53,
+      "count": 84,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 74,
+      "count": 136,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 8,
+      "count": 19,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 67,
+      "count": 153,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 99,
+      "count": 167,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    }
+  ],
+  "KMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 2,
+      "count": 23,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 0,
+      "count": 50,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 61,
+      "count": 93,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 95,
+      "count": 115,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 18,
+      "count": 62,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 2,
+      "count": 58,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 21,
+      "count": 93,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 62,
+      "count": 108,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 74,
+      "count": 117,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 47,
+      "count": 59,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 79,
+      "count": 92,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 82,
+      "count": 144,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 39,
+      "count": 89,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    }
+  ],
+  "KVI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 57,
+      "count": 155,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 30,
+      "count": 68,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 56,
+      "count": 87,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 5,
+      "count": 86,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 30,
+      "count_more": 48,
+      "count": 78,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 3,
+      "count": 79,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 26,
+      "count": 122,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 61,
+      "count_more": 78,
+      "count": 139,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 54,
+      "count": 92,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 86,
+      "count": 102,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 94,
+      "count": 131,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 96,
+      "count": 128,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 11,
+      "count": 49,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    }
+  ],
+  "LCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 93,
+      "count": 113,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 39,
+      "count": 96,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 11,
+      "count": 47,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 46,
+      "count": 91,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 6,
+      "count": 103,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 71,
+      "count": 98,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 16,
+      "count": 20,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 26,
+      "count": 58,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 58,
+      "count": 120,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 11,
+      "count": 77,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 10,
+      "count": 92,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 18,
+      "count": 104,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 60,
+      "count": 126,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    }
+  ],
+  "LEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 63,
+      "count": 120,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 7,
+      "count": 63,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 99,
+      "count": 188,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 27,
+      "count": 102,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 62,
+      "count": 126,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 78,
+      "count": 149,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 64,
+      "count": 130,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 78,
+      "count": 99,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 74,
+      "count": 95,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 80,
+      "count": 80,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 99,
+      "count": 184,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 66,
+      "count": 66,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 1,
+      "count": 80,
+      "prop_one": 0.99,
+      "prop_more": 0.01
+    }
+  ],
+  "LFI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 14,
+      "count": 91,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 94,
+      "count": 138,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 15,
+      "count": 102,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 57,
+      "count": 125,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 53,
+      "count": 111,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 9,
+      "count": 66,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 16,
+      "count": 26,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 55,
+      "count": 131,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 68,
+      "count": 159,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 9,
+      "count": 40,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 96,
+      "count_more": 79,
+      "count": 175,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 65,
+      "count": 151,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 97,
+      "count": 99,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    }
+  ],
+  "LGI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 36,
+      "count": 78,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 11,
+      "count": 104,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 10,
+      "count_more": 73,
+      "count": 83,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 3,
+      "count": 34,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 22,
+      "count": 22,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 69,
+      "count": 156,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 84,
+      "count": 181,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 37,
+      "count": 54,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 3,
+      "count": 6,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 51,
+      "count": 136,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 9,
+      "count": 97,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 37,
+      "count": 41,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 29,
+      "count": 80,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    }
+  ],
+  "LHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 93,
+      "count": 111,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 87,
+      "count": 135,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 65,
+      "count": 151,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 72,
+      "count": 135,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 26,
+      "count_more": 49,
+      "count": 75,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 63,
+      "count": 119,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 26,
+      "count": 60,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 18,
+      "count": 38,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 35,
+      "count": 111,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 28,
+      "count": 65,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 20,
+      "count": 33,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 42,
+      "count": 90,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 72,
+      "count": 158,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    }
+  ],
+  "LII": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 22,
+      "count": 120,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 3,
+      "count": 71,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 16,
+      "count": 87,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 77,
+      "count": 166,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 57,
+      "count": 63,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 35,
+      "count": 36,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 98,
+      "count": 189,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 50,
+      "count": 135,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 28,
+      "count": 67,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 95,
+      "count": 151,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 77,
+      "count": 157,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 50,
+      "count": 64,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 69,
+      "count": 92,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    }
+  ],
+  "LLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 61,
+      "count": 98,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 55,
+      "count_more": 41,
+      "count": 96,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 43,
+      "count": 101,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 65,
+      "count_more": 17,
+      "count": 82,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 30,
+      "count_more": 71,
+      "count": 101,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 37,
+      "count": 134,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 51,
+      "count": 79,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 25,
+      "count_more": 72,
+      "count": 97,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 44,
+      "count_more": 9,
+      "count": 53,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 44,
+      "count": 90,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 84,
+      "count": 136,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 93,
+      "count_more": 29,
+      "count": 122,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 99,
+      "count": 102,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    }
+  ],
+  "LNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 28,
+      "count": 42,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 72,
+      "count_more": 85,
+      "count": 157,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 72,
+      "count_more": 72,
+      "count": 144,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 56,
+      "count": 94,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 99,
+      "count": 128,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 29,
+      "count": 64,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 74,
+      "count": 90,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 34,
+      "count": 125,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 8,
+      "count": 37,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 44,
+      "count": 138,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 45,
+      "count": 136,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 83,
+      "count": 131,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 27,
+      "count": 118,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    }
+  ],
+  "LPI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 14,
+      "count": 33,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 67,
+      "count": 83,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 56,
+      "count": 70,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 1,
+      "count": 19,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 14,
+      "count": 97,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 59,
+      "count": 92,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 19,
+      "count": 50,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 90,
+      "count_more": 17,
+      "count": 107,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 44,
+      "count_more": 57,
+      "count": 101,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 6,
+      "count": 60,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 71,
+      "count": 138,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 83,
+      "count_more": 75,
+      "count": 158,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 56,
+      "count": 106,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    }
+  ],
+  "LTI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 69,
+      "count": 84,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 42,
+      "count": 87,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 15,
+      "count": 83,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 2,
+      "count": 75,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 76,
+      "count": 82,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 34,
+      "count": 132,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 41,
+      "count": 60,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 5,
+      "count": 74,
+      "prop_one": 0.93,
+      "prop_more": 0.07
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 75,
+      "count": 156,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 49,
+      "count": 83,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 2,
+      "count": 71,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 22,
+      "count": 80,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 26,
+      "count": 53,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    }
+  ],
+  "LWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 11,
+      "count": 74,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 40,
+      "count": 46,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 22,
+      "count": 66,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 66,
+      "count_more": 71,
+      "count": 137,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 16,
+      "count": 24,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 17,
+      "count_more": 3,
+      "count": 20,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 99,
+      "count": 178,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 44,
+      "count": 111,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 6,
+      "count": 34,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 74,
+      "count": 125,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 83,
+      "count": 99,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 69,
+      "count": 82,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 99,
+      "count_more": 46,
+      "count": 145,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    }
+  ],
+  "LYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 96,
+      "count": 159,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 74,
+      "count": 96,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 87,
+      "count": 88,
+      "prop_one": 0.01,
+      "prop_more": 0.99
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 94,
+      "count_more": 54,
+      "count": 148,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 23,
+      "count": 47,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 48,
+      "count": 60,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 55,
+      "count": 120,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 36,
+      "count": 62,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 68,
+      "count": 91,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 11,
+      "count": 21,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 6,
+      "count": 81,
+      "prop_one": 0.93,
+      "prop_more": 0.07
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 12,
+      "count": 50,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 28,
+      "count": 96,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    }
+  ],
+  "MDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 32,
+      "count": 53,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 42,
+      "count_more": 10,
+      "count": 52,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 38,
+      "count": 58,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 84,
+      "count": 173,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 44,
+      "count": 135,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 61,
+      "count": 97,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 24,
+      "count": 91,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 83,
+      "count_more": 16,
+      "count": 99,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 45,
+      "count": 59,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 3,
+      "count": 78,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 35,
+      "count_more": 90,
+      "count": 125,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 52,
+      "count": 110,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 91,
+      "count": 139,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    }
+  ],
+  "MHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 15,
+      "count": 23,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 46,
+      "count": 64,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 93,
+      "count": 136,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 54,
+      "count_more": 54,
+      "count": 108,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 93,
+      "count": 177,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 74,
+      "count": 131,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 73,
+      "count": 129,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 80,
+      "count": 87,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 92,
+      "count": 158,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 44,
+      "count": 58,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 27,
+      "count_more": 1,
+      "count": 28,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 93,
+      "count": 187,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 19,
+      "count": 38,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    }
+  ],
+  "MRI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 44,
+      "count": 111,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 83,
+      "count": 140,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 42,
+      "count": 91,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 27,
+      "count": 102,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 48,
+      "count": 83,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 26,
+      "count": 31,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 30,
+      "count": 115,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 52,
+      "count": 140,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 46,
+      "count": 87,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 96,
+      "count": 183,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 13,
+      "count": 104,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 31,
+      "count": 39,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 12,
+      "count": 92,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    }
+  ],
+  "MSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 37,
+      "count": 105,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 51,
+      "count": 137,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 22,
+      "count": 24,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 6,
+      "count": 56,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 40,
+      "count": 133,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 53,
+      "count_more": 41,
+      "count": 94,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 95,
+      "count": 154,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 35,
+      "count": 38,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 1,
+      "count": 30,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 49,
+      "count_more": 96,
+      "count": 145,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 41,
+      "count": 132,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 14,
+      "count": 85,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 65,
+      "count": 162,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    }
+  ],
+  "MTI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 81,
+      "count": 170,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 94,
+      "count_more": 5,
+      "count": 99,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 15,
+      "count": 16,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 87,
+      "count": 118,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 25,
+      "count": 58,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 19,
+      "count": 105,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 51,
+      "count": 63,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 99,
+      "count": 130,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 44,
+      "count": 95,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 2,
+      "count": 7,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 48,
+      "count": 130,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 34,
+      "count": 77,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 40,
+      "count": 135,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    }
+  ],
+  "NHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 47,
+      "count": 90,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 10,
+      "count": 44,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 45,
+      "count": 50,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 9,
+      "count": 73,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 74,
+      "count": 102,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 35,
+      "count": 103,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 73,
+      "count": 129,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 24,
+      "count": 24,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 99,
+      "count": 115,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 44,
+      "count_more": 60,
+      "count": 104,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 98,
+      "count": 114,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 85,
+      "count": 160,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 66,
+      "count": 133,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    }
+  ],
+  "NLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 94,
+      "count": 164,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 16,
+      "count": 74,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 46,
+      "count": 70,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 98,
+      "count": 182,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 35,
+      "count": 99,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 66,
+      "count": 98,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 79,
+      "count": 118,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 88,
+      "count_more": 26,
+      "count": 114,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 27,
+      "count": 113,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 92,
+      "count": 105,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 29,
+      "count": 50,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 32,
+      "count": 129,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 50,
+      "count": 119,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    }
+  ],
+  "NMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 44,
+      "count": 47,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 87,
+      "count": 170,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 87,
+      "count": 143,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 86,
+      "count_more": 81,
+      "count": 167,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 44,
+      "count": 56,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 94,
+      "count": 109,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 93,
+      "count": 114,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 35,
+      "count_more": 42,
+      "count": 77,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 26,
+      "count": 74,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 15,
+      "count": 34,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 32,
+      "count": 129,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 75,
+      "count": 144,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 6,
+      "count": 6,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    }
+  ],
+  "NSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 90,
+      "count_more": 77,
+      "count": 167,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 18,
+      "count_more": 53,
+      "count": 71,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 5,
+      "count": 63,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 31,
+      "count": 99,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 54,
+      "count_more": 28,
+      "count": 82,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 49,
+      "count": 122,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 3,
+      "count": 82,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 5,
+      "count": 103,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 17,
+      "count": 25,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 22,
+      "count_more": 67,
+      "count": 89,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 40,
+      "count": 48,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 17,
+      "count": 51,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 31,
+      "count": 68,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    }
+  ],
+  "NWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 72,
+      "count_more": 36,
+      "count": 108,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 47,
+      "count": 146,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 52,
+      "count_more": 0,
+      "count": 52,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 77,
+      "count": 152,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 39,
+      "count": 115,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 62,
+      "count": 74,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 69,
+      "count": 97,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 84,
+      "count": 110,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 94,
+      "count": 98,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 73,
+      "count": 125,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 22,
+      "count_more": 57,
+      "count": 79,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 55,
+      "count": 71,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 63,
+      "count": 132,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    }
+  ],
+  "ONI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 0,
+      "count": 0,
+      "prop_one": NaN,
+      "prop_more": NaN
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 64,
+      "count": 83,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 88,
+      "count_more": 37,
+      "count": 125,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 40,
+      "count": 102,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 90,
+      "count": 182,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 61,
+      "count_more": 61,
+      "count": 122,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 17,
+      "count": 94,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 68,
+      "count": 100,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 41,
+      "count": 79,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 52,
+      "count": 122,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 69,
+      "count": 72,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 59,
+      "count_more": 32,
+      "count": 91,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 65,
+      "count": 137,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    }
+  ],
+  "OWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 75,
+      "count": 145,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 62,
+      "count": 120,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 7,
+      "count_more": 26,
+      "count": 33,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 97,
+      "count": 120,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 83,
+      "count_more": 8,
+      "count": 91,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 42,
+      "count": 104,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 50,
+      "count": 129,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 8,
+      "count": 106,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 2,
+      "count": 52,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 48,
+      "count": 116,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 54,
+      "count": 135,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 49,
+      "count_more": 62,
+      "count": 111,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 5,
+      "count": 83,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    }
+  ],
+  "PBI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 45,
+      "count": 101,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 9,
+      "count": 17,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 72,
+      "count": 118,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 37,
+      "count": 110,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 14,
+      "count": 62,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 32,
+      "count": 109,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 47,
+      "count": 71,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 33,
+      "count": 62,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 19,
+      "count": 106,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 96,
+      "count": 103,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 8,
+      "count": 12,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 12,
+      "count_more": 52,
+      "count": 64,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 12,
+      "count": 96,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    }
+  ],
+  "PDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 87,
+      "count": 178,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 80,
+      "count_more": 83,
+      "count": 163,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 3,
+      "count": 7,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 84,
+      "count": 125,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 66,
+      "count": 69,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 48,
+      "count": 98,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 19,
+      "count": 58,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 42,
+      "count": 106,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 4,
+      "count": 82,
+      "prop_one": 0.95,
+      "prop_more": 0.05
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 97,
+      "count": 183,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 69,
+      "count": 155,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 54,
+      "count": 83,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 23,
+      "count": 73,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    }
+  ],
+  "PFI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 92,
+      "count": 98,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 53,
+      "count": 137,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 77,
+      "count": 145,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 66,
+      "count": 163,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 29,
+      "count": 118,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 56,
+      "count": 59,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 10,
+      "count": 33,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 82,
+      "count": 105,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 9,
+      "count_more": 28,
+      "count": 37,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 27,
+      "count": 97,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 71,
+      "count": 137,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 9,
+      "count": 40,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 37,
+      "count": 38,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    }
+  ],
+  "PNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 55,
+      "count_more": 85,
+      "count": 140,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 29,
+      "count": 74,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 61,
+      "count": 160,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 41,
+      "count": 99,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 14,
+      "count": 34,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 79,
+      "count": 152,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 58,
+      "count": 136,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 20,
+      "count": 106,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 33,
+      "count_more": 2,
+      "count": 35,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 84,
+      "count": 86,
+      "prop_one": 0.02,
+      "prop_more": 0.98
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 41,
+      "count": 80,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 74,
+      "count_more": 36,
+      "count": 110,
+      "prop_one": 0.67,
+      "prop_more": 0.33
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 85,
+      "count_more": 48,
+      "count": 133,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    }
+  ],
+  "PRI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 21,
+      "count": 35,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 40,
+      "count_more": 57,
+      "count": 97,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 60,
+      "count": 118,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 77,
+      "count": 82,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 91,
+      "count": 149,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 88,
+      "count": 107,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 80,
+      "count": 123,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 97,
+      "count": 164,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 8,
+      "count": 84,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 82,
+      "count": 102,
+      "prop_one": 0.2,
+      "prop_more": 0.8
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 73,
+      "count": 150,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 19,
+      "count": 96,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 83,
+      "count": 170,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    }
+  ],
+  "PVI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 33,
+      "count": 61,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 52,
+      "count_more": 39,
+      "count": 91,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 23,
+      "count": 105,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 31,
+      "count": 127,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 62,
+      "count": 89,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 25,
+      "count": 36,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 28,
+      "count": 73,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 26,
+      "count": 39,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 5,
+      "count": 34,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 34,
+      "count": 75,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 10,
+      "count": 85,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 69,
+      "count": 150,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 94,
+      "count": 158,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    }
+  ],
+  "PYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 19,
+      "count": 111,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 72,
+      "count": 143,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 23,
+      "count": 107,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 90,
+      "count_more": 2,
+      "count": 92,
+      "prop_one": 0.98,
+      "prop_more": 0.02
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 53,
+      "count_more": 15,
+      "count": 68,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 69,
+      "count_more": 45,
+      "count": 114,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 34,
+      "count": 84,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 89,
+      "count": 184,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 42,
+      "count": 95,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 50,
+      "count": 82,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 89,
+      "count": 154,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 72,
+      "count": 120,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 58,
+      "count": 106,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    }
+  ],
+  "RCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 7,
+      "count_more": 34,
+      "count": 41,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 54,
+      "count": 103,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 15,
+      "count": 65,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 87,
+      "count": 108,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 0,
+      "count": 35,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 17,
+      "count": 32,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 79,
+      "count": 144,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 26,
+      "count": 80,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 63,
+      "count": 109,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 30,
+      "count": 93,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 53,
+      "count": 116,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 32,
+      "count": 74,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 42,
+      "count_more": 1,
+      "count": 43,
+      "prop_one": 0.98,
+      "prop_more": 0.02
+    }
+  ],
+  "RHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 29,
+      "count": 58,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 62,
+      "count_more": 9,
+      "count": 71,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 40,
+      "count_more": 43,
+      "count": 83,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 42,
+      "count": 76,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 81,
+      "count": 151,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 69,
+      "count": 128,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 61,
+      "count_more": 71,
+      "count": 132,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 40,
+      "count": 103,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 94,
+      "count": 160,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 33,
+      "count": 35,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 19,
+      "count": 92,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 11,
+      "count_more": 30,
+      "count": 41,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 24,
+      "count_more": 69,
+      "count": 93,
+      "prop_one": 0.26,
+      "prop_more": 0.74
+    }
+  ],
+  "RNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 40,
+      "count": 40,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 67,
+      "count_more": 75,
+      "count": 142,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 52,
+      "count": 150,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 29,
+      "count": 40,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 2,
+      "count": 45,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 32,
+      "count": 117,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 45,
+      "count": 111,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 26,
+      "count_more": 62,
+      "count": 88,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 27,
+      "count": 94,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 87,
+      "count_more": 92,
+      "count": 179,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 74,
+      "count": 143,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 27,
+      "count": 118,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 17,
+      "count": 30,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    }
+  ],
+  "RSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 92,
+      "count_more": 63,
+      "count": 155,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 49,
+      "count": 108,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 61,
+      "count_more": 82,
+      "count": 143,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 49,
+      "count": 86,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 88,
+      "count": 161,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 49,
+      "count": 65,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 51,
+      "count": 58,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 10,
+      "count": 108,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 82,
+      "count": 121,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 28,
+      "count": 94,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 90,
+      "count_more": 10,
+      "count": 100,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 78,
+      "count_more": 31,
+      "count": 109,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 88,
+      "count": 101,
+      "prop_one": 0.13,
+      "prop_more": 0.87
+    }
+  ],
+  "SDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 54,
+      "count": 68,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 22,
+      "count": 44,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 51,
+      "count": 53,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 84,
+      "count_more": 43,
+      "count": 127,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 94,
+      "count": 173,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 85,
+      "count_more": 72,
+      "count": 157,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 99,
+      "count_more": 66,
+      "count": 165,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 68,
+      "count": 147,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 85,
+      "count": 130,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 57,
+      "count_more": 66,
+      "count": 123,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 34,
+      "count": 73,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 15,
+      "count": 23,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 78,
+      "count": 121,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    }
+  ],
+  "SFI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 31,
+      "count_more": 73,
+      "count": 104,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 31,
+      "count": 50,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 51,
+      "count": 83,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 7,
+      "count": 23,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 61,
+      "count_more": 78,
+      "count": 139,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 62,
+      "count": 64,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 28,
+      "count_more": 42,
+      "count": 70,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 74,
+      "count_more": 1,
+      "count": 75,
+      "prop_one": 0.99,
+      "prop_more": 0.01
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 40,
+      "count": 74,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 15,
+      "count_more": 8,
+      "count": 23,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 98,
+      "count": 106,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 85,
+      "count": 131,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 81,
+      "count": 151,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    }
+  ],
+  "SHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 99,
+      "count_more": 50,
+      "count": 149,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 69,
+      "count": 88,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 90,
+      "count": 93,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 32,
+      "count": 65,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 76,
+      "count_more": 64,
+      "count": 140,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 54,
+      "count": 149,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 53,
+      "count": 93,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 23,
+      "count": 94,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 88,
+      "count": 142,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 94,
+      "count": 115,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 99,
+      "count_more": 13,
+      "count": 112,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 43,
+      "count": 106,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 16,
+      "count_more": 19,
+      "count": 35,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    }
+  ],
+  "SKI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 70,
+      "count": 166,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 94,
+      "count": 171,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 31,
+      "count": 37,
+      "prop_one": 0.16,
+      "prop_more": 0.84
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 20,
+      "count_more": 99,
+      "count": 119,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 34,
+      "count_more": 32,
+      "count": 66,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 68,
+      "count": 109,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 26,
+      "count": 71,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 76,
+      "count": 144,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 25,
+      "count": 33,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 98,
+      "count": 143,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 75,
+      "count": 172,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 24,
+      "count": 100,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 18,
+      "count": 31,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    }
+  ],
+  "SLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 72,
+      "count_more": 2,
+      "count": 74,
+      "prop_one": 0.97,
+      "prop_more": 0.03
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 31,
+      "count": 105,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 17,
+      "count": 18,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 38,
+      "count": 88,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 65,
+      "count_more": 64,
+      "count": 129,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 78,
+      "count": 171,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 58,
+      "count_more": 43,
+      "count": 101,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 99,
+      "count": 170,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 33,
+      "count": 47,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 50,
+      "count": 103,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 58,
+      "count": 65,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 98,
+      "count": 149,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 53,
+      "count": 60,
+      "prop_one": 0.12,
+      "prop_more": 0.88
+    }
+  ],
+  "SNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 18,
+      "count": 92,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 39,
+      "count": 80,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 11,
+      "count_more": 97,
+      "count": 108,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 75,
+      "count": 170,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 53,
+      "count": 126,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 69,
+      "count_more": 24,
+      "count": 93,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 90,
+      "count": 93,
+      "prop_one": 0.03,
+      "prop_more": 0.97
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 90,
+      "count_more": 30,
+      "count": 120,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 26,
+      "count": 124,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 30,
+      "count": 84,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 36,
+      "count_more": 76,
+      "count": 112,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 31,
+      "count_more": 70,
+      "count": 101,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 59,
+      "count": 141,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    }
+  ],
+  "SPI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 1,
+      "count": 15,
+      "prop_one": 0.93,
+      "prop_more": 0.07
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 75,
+      "count_more": 79,
+      "count": 154,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 78,
+      "count": 156,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 25,
+      "count_more": 5,
+      "count": 30,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 39,
+      "count_more": 54,
+      "count": 93,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 21,
+      "count": 84,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 85,
+      "count": 125,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 44,
+      "count": 123,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 56,
+      "count": 77,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 38,
+      "count": 90,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 81,
+      "count": 173,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 25,
+      "count": 29,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 71,
+      "count": 117,
+      "prop_one": 0.39,
+      "prop_more": 0.61
+    }
+  ],
+  "STI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 51,
+      "count": 95,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 72,
+      "count": 105,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 53,
+      "count_more": 21,
+      "count": 74,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 21,
+      "count_more": 56,
+      "count": 77,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 32,
+      "count": 65,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 14,
+      "count": 109,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 35,
+      "count": 75,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 64,
+      "count": 159,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 15,
+      "count_more": 84,
+      "count": 99,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 45,
+      "count_more": 0,
+      "count": 45,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 95,
+      "count_more": 34,
+      "count": 129,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 17,
+      "count": 82,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 65,
+      "count_more": 91,
+      "count": 156,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    }
+  ],
+  "SUI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 79,
+      "count": 128,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 11,
+      "count": 85,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 51,
+      "count": 146,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 43,
+      "count": 46,
+      "prop_one": 0.07,
+      "prop_more": 0.93
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 69,
+      "count": 150,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 81,
+      "count": 163,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 1,
+      "count_more": 0,
+      "count": 1,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 81,
+      "count": 91,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 32,
+      "count": 95,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 51,
+      "count": 102,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 48,
+      "count_more": 12,
+      "count": 60,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 36,
+      "count_more": 46,
+      "count": 82,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 15,
+      "count": 86,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    }
+  ],
+  "SWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 17,
+      "count": 110,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 73,
+      "count_more": 19,
+      "count": 92,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 94,
+      "count_more": 58,
+      "count": 152,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 41,
+      "count": 82,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 74,
+      "count_more": 28,
+      "count": 102,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 22,
+      "count_more": 61,
+      "count": 83,
+      "prop_one": 0.27,
+      "prop_more": 0.73
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 52,
+      "count": 138,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 15,
+      "count": 96,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 89,
+      "count": 119,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 11,
+      "count": 88,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 94,
+      "count": 137,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 55,
+      "count_more": 31,
+      "count": 86,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 12,
+      "count": 35,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    }
+  ],
+  "TCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 82,
+      "count": 90,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 20,
+      "count": 20,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 28,
+      "count_more": 17,
+      "count": 45,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 80,
+      "count": 158,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 27,
+      "count": 85,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 25,
+      "count": 69,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 93,
+      "count": 149,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 2,
+      "count": 23,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 68,
+      "count": 138,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 25,
+      "count": 95,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 64,
+      "count": 115,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 47,
+      "count_more": 26,
+      "count": 73,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 94,
+      "count": 99,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    }
+  ],
+  "TSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 24,
+      "count_more": 45,
+      "count": 69,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 9,
+      "count": 68,
+      "prop_one": 0.87,
+      "prop_more": 0.13
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 48,
+      "count": 53,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 52,
+      "count_more": 5,
+      "count": 57,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 78,
+      "count": 157,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 23,
+      "count_more": 13,
+      "count": 36,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 41,
+      "count": 64,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 75,
+      "count": 114,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 91,
+      "count": 175,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 90,
+      "count_more": 77,
+      "count": 167,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 0,
+      "count": 34,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 85,
+      "count": 108,
+      "prop_one": 0.21,
+      "prop_more": 0.79
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 54,
+      "count": 117,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    }
+  ],
+  "UKI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 19,
+      "count_more": 63,
+      "count": 82,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 81,
+      "count_more": 23,
+      "count": 104,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 56,
+      "count": 116,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 59,
+      "count_more": 95,
+      "count": 154,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 52,
+      "count": 98,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 52,
+      "count": 79,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 59,
+      "count": 151,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 98,
+      "count_more": 70,
+      "count": 168,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 12,
+      "count": 84,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 60,
+      "count_more": 81,
+      "count": 141,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 34,
+      "count": 42,
+      "prop_one": 0.19,
+      "prop_more": 0.81
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 60,
+      "count_more": 73,
+      "count": 133,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 82,
+      "count": 155,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    }
+  ],
+  "UPI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 46,
+      "count": 84,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 67,
+      "count": 163,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 38,
+      "count_more": 74,
+      "count": 112,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 95,
+      "count_more": 51,
+      "count": 146,
+      "prop_one": 0.65,
+      "prop_more": 0.35
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 90,
+      "count": 119,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 11,
+      "count": 48,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 7,
+      "count_more": 77,
+      "count": 84,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 30,
+      "count": 43,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 62,
+      "count_more": 64,
+      "count": 126,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 10,
+      "count": 13,
+      "prop_one": 0.23,
+      "prop_more": 0.77
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 89,
+      "count_more": 0,
+      "count": 89,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 50,
+      "count": 125,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 15,
+      "count": 82,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    }
+  ],
+  "VEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 69,
+      "count": 132,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 95,
+      "count": 140,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 87,
+      "count": 120,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 38,
+      "count": 106,
+      "prop_one": 0.64,
+      "prop_more": 0.36
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 5,
+      "count": 6,
+      "prop_one": 0.17,
+      "prop_more": 0.83
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 43,
+      "count_more": 32,
+      "count": 75,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 72,
+      "count": 148,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 32,
+      "count": 129,
+      "prop_one": 0.75,
+      "prop_more": 0.25
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 77,
+      "count_more": 10,
+      "count": 87,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 99,
+      "count": 142,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 43,
+      "count_more": 18,
+      "count": 61,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 25,
+      "count": 91,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 79,
+      "count": 133,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    }
+  ],
+  "WCI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 65,
+      "count": 101,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 46,
+      "count": 123,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 10,
+      "count": 22,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 23,
+      "count": 120,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 25,
+      "count_more": 7,
+      "count": 32,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 25,
+      "count": 112,
+      "prop_one": 0.78,
+      "prop_more": 0.22
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 97,
+      "count_more": 87,
+      "count": 184,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 82,
+      "count": 119,
+      "prop_one": 0.31,
+      "prop_more": 0.69
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 19,
+      "count": 73,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 15,
+      "count": 49,
+      "prop_one": 0.69,
+      "prop_more": 0.31
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 32,
+      "count_more": 58,
+      "count": 90,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 21,
+      "count": 87,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 15,
+      "count_more": 84,
+      "count": 99,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    }
+  ],
+  "WDI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 47,
+      "count": 111,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 2,
+      "count": 100,
+      "prop_one": 0.98,
+      "prop_more": 0.02
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 3,
+      "count_more": 27,
+      "count": 30,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 2,
+      "count_more": 41,
+      "count": 43,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 42,
+      "count": 83,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 14,
+      "count": 60,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 81,
+      "count_more": 75,
+      "count": 156,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 57,
+      "count": 60,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 67,
+      "count": 71,
+      "prop_one": 0.06,
+      "prop_more": 0.94
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 33,
+      "count": 53,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 38,
+      "count": 132,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 10,
+      "count_more": 85,
+      "count": 95,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 0,
+      "count": 17,
+      "prop_one": 1.0,
+      "prop_more": 0.0
+    }
+  ],
+  "WEI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 32,
+      "count_more": 77,
+      "count": 109,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 26,
+      "count_more": 62,
+      "count": 88,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 0,
+      "count_more": 66,
+      "count": 66,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 24,
+      "count": 70,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 9,
+      "count_more": 96,
+      "count": 105,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 89,
+      "count_more": 84,
+      "count": 173,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 84,
+      "count_more": 22,
+      "count": 106,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 51,
+      "count_more": 63,
+      "count": 114,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 39,
+      "count_more": 81,
+      "count": 120,
+      "prop_one": 0.32,
+      "prop_more": 0.68
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 55,
+      "count": 147,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 57,
+      "count": 121,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 36,
+      "count_more": 27,
+      "count": 63,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 73,
+      "count_more": 66,
+      "count": 139,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    }
+  ],
+  "WHI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 7,
+      "count": 56,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 41,
+      "count_more": 13,
+      "count": 54,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 20,
+      "count": 118,
+      "prop_one": 0.83,
+      "prop_more": 0.17
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 87,
+      "count": 114,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 33,
+      "count": 103,
+      "prop_one": 0.68,
+      "prop_more": 0.32
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 90,
+      "count_more": 97,
+      "count": 187,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 13,
+      "count_more": 60,
+      "count": 73,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 57,
+      "count": 148,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 47,
+      "count": 117,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 86,
+      "count_more": 79,
+      "count": 165,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 47,
+      "count": 70,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 70,
+      "count": 74,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 19,
+      "count_more": 34,
+      "count": 53,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    }
+  ],
+  "WII": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 85,
+      "count": 133,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 70,
+      "count_more": 86,
+      "count": 156,
+      "prop_one": 0.45,
+      "prop_more": 0.55
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 93,
+      "count_more": 69,
+      "count": 162,
+      "prop_one": 0.57,
+      "prop_more": 0.43
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 45,
+      "count_more": 28,
+      "count": 73,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 12,
+      "count_more": 36,
+      "count": 48,
+      "prop_one": 0.25,
+      "prop_more": 0.75
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 64,
+      "count": 155,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 2,
+      "count_more": 54,
+      "count": 56,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 79,
+      "count_more": 23,
+      "count": 102,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 41,
+      "count": 46,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 18,
+      "count_more": 36,
+      "count": 54,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 91,
+      "count_more": 4,
+      "count": 95,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 41,
+      "count_more": 62,
+      "count": 103,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 46,
+      "count_more": 87,
+      "count": 133,
+      "prop_one": 0.35,
+      "prop_more": 0.65
+    }
+  ],
+  "WLI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 87,
+      "count_more": 92,
+      "count": 179,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 68,
+      "count_more": 27,
+      "count": 95,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 60,
+      "count": 89,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 8,
+      "count": 52,
+      "prop_one": 0.85,
+      "prop_more": 0.15
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 33,
+      "count_more": 85,
+      "count": 118,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 77,
+      "count_more": 85,
+      "count": 162,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 92,
+      "count_more": 22,
+      "count": 114,
+      "prop_one": 0.81,
+      "prop_more": 0.19
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 76,
+      "count_more": 39,
+      "count": 115,
+      "prop_one": 0.66,
+      "prop_more": 0.34
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 29,
+      "count_more": 52,
+      "count": 81,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 76,
+      "count": 170,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 4,
+      "count_more": 72,
+      "count": 76,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 44,
+      "count": 119,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 35,
+      "count": 129,
+      "prop_one": 0.73,
+      "prop_more": 0.27
+    }
+  ],
+  "WMI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 25,
+      "count_more": 27,
+      "count": 52,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 35,
+      "count_more": 91,
+      "count": 126,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 58,
+      "count_more": 41,
+      "count": 99,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 33,
+      "count": 62,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 14,
+      "count_more": 25,
+      "count": 39,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 1,
+      "count_more": 18,
+      "count": 19,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 68,
+      "count_more": 54,
+      "count": 122,
+      "prop_one": 0.56,
+      "prop_more": 0.44
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 50,
+      "count_more": 30,
+      "count": 80,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 4,
+      "count": 70,
+      "prop_one": 0.94,
+      "prop_more": 0.06
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 14,
+      "count_more": 24,
+      "count": 38,
+      "prop_one": 0.37,
+      "prop_more": 0.63
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 8,
+      "count_more": 98,
+      "count": 106,
+      "prop_one": 0.08,
+      "prop_more": 0.92
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 57,
+      "count_more": 6,
+      "count": 63,
+      "prop_one": 0.9,
+      "prop_more": 0.1
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 12,
+      "count": 83,
+      "prop_one": 0.86,
+      "prop_more": 0.14
+    }
+  ],
+  "WNI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 44,
+      "count_more": 86,
+      "count": 130,
+      "prop_one": 0.34,
+      "prop_more": 0.66
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 22,
+      "count": 93,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 27,
+      "count_more": 55,
+      "count": 82,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 37,
+      "count_more": 23,
+      "count": 60,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 98,
+      "count_more": 40,
+      "count": 138,
+      "prop_one": 0.71,
+      "prop_more": 0.29
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 82,
+      "count_more": 96,
+      "count": 178,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 76,
+      "count": 114,
+      "prop_one": 0.33,
+      "prop_more": 0.67
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 52,
+      "count_more": 30,
+      "count": 82,
+      "prop_one": 0.63,
+      "prop_more": 0.37
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 93,
+      "count": 133,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 83,
+      "count_more": 78,
+      "count": 161,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 25,
+      "count": 63,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 28,
+      "count": 92,
+      "prop_one": 0.7,
+      "prop_more": 0.3
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 63,
+      "count_more": 66,
+      "count": 129,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    }
+  ],
+  "WRI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 53,
+      "count_more": 73,
+      "count": 126,
+      "prop_one": 0.42,
+      "prop_more": 0.58
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 57,
+      "count_more": 39,
+      "count": 96,
+      "prop_one": 0.59,
+      "prop_more": 0.41
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 48,
+      "count_more": 79,
+      "count": 127,
+      "prop_one": 0.38,
+      "prop_more": 0.62
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 18,
+      "count": 89,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 91,
+      "count": 106,
+      "prop_one": 0.14,
+      "prop_more": 0.86
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 29,
+      "count": 75,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 66,
+      "count_more": 83,
+      "count": 149,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 5,
+      "count_more": 51,
+      "count": 56,
+      "prop_one": 0.09,
+      "prop_more": 0.91
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 75,
+      "count_more": 74,
+      "count": 149,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 64,
+      "count_more": 14,
+      "count": 78,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 54,
+      "count_more": 51,
+      "count": 105,
+      "prop_one": 0.51,
+      "prop_more": 0.49
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 93,
+      "count_more": 24,
+      "count": 117,
+      "prop_one": 0.79,
+      "prop_more": 0.21
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 57,
+      "count_more": 68,
+      "count": 125,
+      "prop_one": 0.46,
+      "prop_more": 0.54
+    }
+  ],
+  "WSI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 97,
+      "count_more": 85,
+      "count": 182,
+      "prop_one": 0.53,
+      "prop_more": 0.47
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 36,
+      "count_more": 7,
+      "count": 43,
+      "prop_one": 0.84,
+      "prop_more": 0.16
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 6,
+      "count_more": 15,
+      "count": 21,
+      "prop_one": 0.29,
+      "prop_more": 0.71
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 16,
+      "count_more": 94,
+      "count": 110,
+      "prop_one": 0.15,
+      "prop_more": 0.85
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 12,
+      "count": 103,
+      "prop_one": 0.88,
+      "prop_more": 0.12
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 64,
+      "count_more": 81,
+      "count": 145,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 23,
+      "count": 117,
+      "prop_one": 0.8,
+      "prop_more": 0.2
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 34,
+      "count_more": 29,
+      "count": 63,
+      "prop_one": 0.54,
+      "prop_more": 0.46
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 94,
+      "count_more": 94,
+      "count": 188,
+      "prop_one": 0.5,
+      "prop_more": 0.5
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 37,
+      "count_more": 13,
+      "count": 50,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 67,
+      "count_more": 3,
+      "count": 70,
+      "prop_one": 0.96,
+      "prop_more": 0.04
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 49,
+      "count_more": 6,
+      "count": 55,
+      "prop_one": 0.89,
+      "prop_more": 0.11
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 3,
+      "count_more": 66,
+      "count": 69,
+      "prop_one": 0.04,
+      "prop_more": 0.96
+    }
+  ],
+  "WTI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 15,
+      "count_more": 38,
+      "count": 53,
+      "prop_one": 0.28,
+      "prop_more": 0.72
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 66,
+      "count_more": 21,
+      "count": 87,
+      "prop_one": 0.76,
+      "prop_more": 0.24
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 60,
+      "count_more": 13,
+      "count": 73,
+      "prop_one": 0.82,
+      "prop_more": 0.18
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 8,
+      "count_more": 37,
+      "count": 45,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 91,
+      "count_more": 61,
+      "count": 152,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 61,
+      "count_more": 5,
+      "count": 66,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 7,
+      "count": 27,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 20,
+      "count_more": 72,
+      "count": 92,
+      "prop_one": 0.22,
+      "prop_more": 0.78
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 71,
+      "count_more": 6,
+      "count": 77,
+      "prop_one": 0.92,
+      "prop_more": 0.08
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 80,
+      "count_more": 65,
+      "count": 145,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 76,
+      "count": 158,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 17,
+      "count_more": 78,
+      "count": 95,
+      "prop_one": 0.18,
+      "prop_more": 0.82
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 70,
+      "count_more": 92,
+      "count": 162,
+      "prop_one": 0.43,
+      "prop_more": 0.57
+    }
+  ],
+  "WWI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 63,
+      "count_more": 46,
+      "count": 109,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 79,
+      "count_more": 74,
+      "count": 153,
+      "prop_one": 0.52,
+      "prop_more": 0.48
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 78,
+      "count_more": 82,
+      "count": 160,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 29,
+      "count_more": 19,
+      "count": 48,
+      "prop_one": 0.6,
+      "prop_more": 0.4
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 49,
+      "count_more": 50,
+      "count": 99,
+      "prop_one": 0.49,
+      "prop_more": 0.51
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 96,
+      "count_more": 78,
+      "count": 174,
+      "prop_one": 0.55,
+      "prop_more": 0.45
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 40,
+      "count_more": 26,
+      "count": 66,
+      "prop_one": 0.61,
+      "prop_more": 0.39
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 21,
+      "count_more": 65,
+      "count": 86,
+      "prop_one": 0.24,
+      "prop_more": 0.76
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 54,
+      "count": 77,
+      "prop_one": 0.3,
+      "prop_more": 0.7
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 38,
+      "count_more": 58,
+      "count": 96,
+      "prop_one": 0.4,
+      "prop_more": 0.6
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 30,
+      "count_more": 43,
+      "count": 73,
+      "prop_one": 0.41,
+      "prop_more": 0.59
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 93,
+      "count": 146,
+      "prop_one": 0.36,
+      "prop_more": 0.64
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 23,
+      "count_more": 7,
+      "count": 30,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    }
+  ],
+  "WYI": [
+    {
+      "month": 7,
+      "year": 2022,
+      "count_one": 56,
+      "count_more": 40,
+      "count": 96,
+      "prop_one": 0.58,
+      "prop_more": 0.42
+    },
+    {
+      "month": 8,
+      "year": 2022,
+      "count_one": 71,
+      "count_more": 80,
+      "count": 151,
+      "prop_one": 0.47,
+      "prop_more": 0.53
+    },
+    {
+      "month": 9,
+      "year": 2022,
+      "count_one": 46,
+      "count_more": 18,
+      "count": 64,
+      "prop_one": 0.72,
+      "prop_more": 0.28
+    },
+    {
+      "month": 10,
+      "year": 2022,
+      "count_one": 50,
+      "count_more": 15,
+      "count": 65,
+      "prop_one": 0.77,
+      "prop_more": 0.23
+    },
+    {
+      "month": 11,
+      "year": 2022,
+      "count_one": 4,
+      "count_more": 31,
+      "count": 35,
+      "prop_one": 0.11,
+      "prop_more": 0.89
+    },
+    {
+      "month": 12,
+      "year": 2022,
+      "count_one": 5,
+      "count_more": 95,
+      "count": 100,
+      "prop_one": 0.05,
+      "prop_more": 0.95
+    },
+    {
+      "month": 1,
+      "year": 2023,
+      "count_one": 9,
+      "count_more": 79,
+      "count": 88,
+      "prop_one": 0.1,
+      "prop_more": 0.9
+    },
+    {
+      "month": 2,
+      "year": 2023,
+      "count_one": 72,
+      "count_more": 25,
+      "count": 97,
+      "prop_one": 0.74,
+      "prop_more": 0.26
+    },
+    {
+      "month": 3,
+      "year": 2023,
+      "count_one": 56,
+      "count_more": 70,
+      "count": 126,
+      "prop_one": 0.44,
+      "prop_more": 0.56
+    },
+    {
+      "month": 4,
+      "year": 2023,
+      "count_one": 82,
+      "count_more": 50,
+      "count": 132,
+      "prop_one": 0.62,
+      "prop_more": 0.38
+    },
+    {
+      "month": 5,
+      "year": 2023,
+      "count_one": 69,
+      "count_more": 7,
+      "count": 76,
+      "prop_one": 0.91,
+      "prop_more": 0.09
+    },
+    {
+      "month": 6,
+      "year": 2023,
+      "count_one": 0,
+      "count_more": 53,
+      "count": 53,
+      "prop_one": 0.0,
+      "prop_more": 1.0
+    },
+    {
+      "month": 7,
+      "year": 2023,
+      "count_one": 53,
+      "count_more": 58,
+      "count": 111,
+      "prop_one": 0.48,
+      "prop_more": 0.52
+    }
+  ]
+}


### PR DESCRIPTION
- 5c chart added;
- 'characteristic' query param removed from API as not been used;